### PR TITLE
Fix isNew condition

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -16,7 +16,7 @@ elifeLibrary {
 
     elifeMainlineOnly {
         stage 'Push release', {
-            def isNew = !(sh(script: "git tag | grep v${candidateVersion}", returnStatus: true))
+            def isNew = sh(script: "git tag | grep v${candidateVersion}", returnStatus: true) != 0
             if (isNew) {
                 sh "git tag v${candidateVersion} && git push origin v4{candidateVersion}"
             }


### PR DESCRIPTION
The status code is `0` if grep finds something, so `isNew` should choose to create a new tag only if `grep` has failed.